### PR TITLE
Update xlsx_concatenation.py

### DIFF
--- a/functions/xlsx_concatenation.py
+++ b/functions/xlsx_concatenation.py
@@ -13,9 +13,12 @@ def get_xlsx_files():
 def create_dataframe(xlsx_files):
     dataframes = []
     for file in xlsx_files:
-        status_messages.concatenation(2, file)
-        dataframes.append(pd.read_excel(file, sheet_name=0, index_col=0))
-    dataframe = pd.concat(dataframes, axis=1).T.copy()
+        status_messages.concatenation(2, file)     
+        df_crop_1 = pd.read_excel(file, sheet_name=0, index_col=0).iloc[0:120]
+        df_crop_2 = pd.read_excel(file, sheet_name=0, index_col=0).iloc[125:]
+        df_complete = pd.concat([df_crop_1, df_crop_2], axis=0)        
+        dataframes.append(df_complete)
+    dataframe = pd.concat(dataframes, axis=1).T
     return dataframe
 
 def initiate_export(dataframe, custom_filename, custom_folder):


### PR DESCRIPTION
Fix #3 

**Root cause for bug:**
dataframes.append(pd.read_excel(file, sheet_name=0, index_col=0))

**Description:**
The upper line of code intents to concatenate (and transpose to columns) all rows of all stocks assuming that index labels used as criteria are identical. Due to a change at Yahoo statistics section this is not longer the case. Here is where the bug appears:

In DOW/NASDAQ/NYSE stocks "(dd. mm. yyyy)" is given, in other stocks not. Example, cf. statistics:
- Aktien (Short) (14. Okt. 2020)
- Short Ratio (14. Okt. 2020)
- Short % / Float (14. Okt. 2020)
- Short % der Aktien im Umlauf (14. Okt. 2020)
- Aktien (Short, vorher. Monat 14. Sept. 2020)

Moreover, these dates may be divergent even for US stocks, of course depending on when stocks have been parsed. Since these column labels are used as index for pandas concatenation, it will become out of sync, especially the more stocks are parsed. Function will then crash once different indices are finally merged to one xlsx.

**Solution:**
For now, fix is to cut'em lines out and throw it away. This is done by cropping with .iloc-method:
df_crop_1 = pd.read_excel(file, sheet_name=0, index_col=0).iloc[0:120]
df_crop_2 = pd.read_excel(file, sheet_name=0, index_col=0).iloc[125:]
The rows of the cropped sections then need to be tied together:
df_complete = pd.concat([df_crop_1, df_crop_2], axis=0) 

Once the 5 lines mentioned above are cut out, concatenation will proceed as expected. Minor 2nd change was deleting ".copy()" from ".T.copy()" in same function, last line of code before "return". Not necessary, small performance boost.